### PR TITLE
fix:make compilation error

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,4 +22,4 @@ builds/android_ndk_jni_mk/libs/
 builds/android_ndk_jni_mk/obj/
 hdiffi
 hpatchi
-.vscode/launch.json
+*.vscode/

--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,4 @@ builds/android_ndk_jni_mk/libs/
 builds/android_ndk_jni_mk/obj/
 hdiffi
 hpatchi
+.vscode/launch.json

--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,5 @@ Release_x86
 *.ipch
 builds/android_ndk_jni_mk/libs/
 builds/android_ndk_jni_mk/obj/
+hdiffi
+hpatchi

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,7 @@
 # args
 MT       := 1
 TUZ		   := 1
+DEBUG    ?= 0
 # 0: not need zlib;  1: compile zlib source code;  2: used -lz to link zlib lib;
 ZLIB     := 1
 LZMA     := 1
@@ -106,9 +107,14 @@ else
     $(HDP_PATH)/compress_parallel.o
 endif
 
+ifeq ($(DEBUG),1)
+  DBG_FLAGS := -g -O0
+else
+  DBG_FLAGS := -O3 -DNDEBUG
+endif
 
 DEF_FLAGS := \
-    -O3 -DNDEBUG -D_LARGEFILE_SOURCE -D_FILE_OFFSET_BITS=64 \
+    $(DBG_FLAGS) -D_LARGEFILE_SOURCE -D_FILE_OFFSET_BITS=64 \
     -D_IS_NEED_DEFAULT_CompressPlugin=0
 ifeq ($(M32),0)
 else

--- a/Makefile
+++ b/Makefile
@@ -24,6 +24,16 @@ HPATCHI_OBJ := \
     $(HDP_PATH)/file_for_patch.o \
     $(HDP_PATH)/libHDiffPatch/HPatch/patch.o \
     $(HDP_PATH)/libHDiffPatch/HPatchLite/hpatch_lite.o
+ifeq ($(MT),0)
+else
+  HPATCHI_OBJ += \
+    $(HDP_PATH)/libHDiffPatch/HPatch/hpatch_mt/_hcache_old_mt.o \
+    $(HDP_PATH)/libHDiffPatch/HPatch/hpatch_mt/_hinput_mt.o \
+    $(HDP_PATH)/libHDiffPatch/HPatch/hpatch_mt/_houtput_mt.o \
+    $(HDP_PATH)/libHDiffPatch/HPatch/hpatch_mt/_hpatch_mt.o \
+    $(HDP_PATH)/libHDiffPatch/HPatch/hpatch_mt/hpatch_mt.o \
+    $(HDP_PATH)/libParallel/parallel_import_c.o
+endif
 
 TUZ_PATH := tinyuz
 ifeq ($(TUZ),1) # https://github.com/sisong/tinyuz  
@@ -76,8 +86,8 @@ HDIFF_PATH  := $(HDP_PATH)/libHDiffPatch/HDiff
 HDIFFI_OBJ += \
     hdiffi_import_patch.o \
     $(HDIFF_PATH)/diff.o \
-    $(HDIFF_PATH)/match_inplace.o \
     $(HDIFF_PATH)/match_block.o \
+    $(HDIFF_PATH)/private_diff/match_inplace.o \
     $(HDIFF_PATH)/private_diff/bytes_rle.o \
     $(HDIFF_PATH)/private_diff/suffix_string.o \
     $(HDIFF_PATH)/private_diff/compress_detect.o \
@@ -91,7 +101,7 @@ HDIFFI_OBJ += \
 ifeq ($(MT),0)
 else
   HDIFFI_OBJ += \
-    $(HDP_PATH)/libParallel/parallel_import.o \
+    $(HDP_PATH)/libParallel/parallel_import_c.o \
     $(HDP_PATH)/libParallel/parallel_channel.o \
     $(HDP_PATH)/compress_parallel.o
 endif
@@ -148,18 +158,16 @@ PATCH_LINK :=
 ifeq ($(ZLIB),2)
   PATCH_LINK += -lz			# link zlib
 endif
-ifeq ($(M32),0)
-else
-  PATCH_LINK += -m32
-endif
-ifeq ($(MINS),0)
-else
-  PATCH_LINK += -s -Wl,--gc-sections,--as-needed
-endif
+# ...
 ifeq ($(STATIC_C),0)
 else
   PATCH_LINK += -static
 endif
+ifeq ($(MT),0)
+else
+  PATCH_LINK += -lpthread	# link pthread
+endif
+
 DIFF_LINK  := $(PATCH_LINK)
 ifeq ($(MT),0)
 else

--- a/Makefile
+++ b/Makefile
@@ -201,6 +201,7 @@ hdiffi: libhpatchlite.a
 ifeq ($(OS),Windows_NT) # mingw?
   RM := del /Q /F
   DEL_HDIFFI_OBJ := $(subst /,\,$(HDIFFI_OBJ))
+  DEF_FLAGS += -D_WIN32_WINNT=0x0600
 else
   RM := rm -f
   DEL_HDIFFI_OBJ := $(HDIFFI_OBJ)


### PR DESCRIPTION
```sh
In file included from hpatchi.c:10:
HDiffPatch/_clock_for_demo.h: In function 'clock_s':
HDiffPatch/_clock_for_demo.h:42:16: warning: implicit declaration of function 'GetTickCount64'; did you mean 'GetTickCount'? [-Wimplicit-function-declaration]
return GetTickCount64()/1000.0;
^~~~~~~~~~~~~~
GetTickCount
In file included from hdiffi.cpp:19:
HDiffPatch/_clock_for_demo.h: In function 'double clock_s()':
HDiffPatch/_clock_for_demo.h:42:16: error: 'GetTickCount64' was not declared in this scope
return GetTickCount64()/1000.0;
^~~~~~~~~~~~~~
HDiffPatch/_clock_for_demo.h:42:16: note: suggested alternative: 'GetTickCount'
return GetTickCount64()/1000.0;
^~~~~~~~~~~~~~
GetTickCount
make: *** [Makefile:199: hdiffi] Error 1
```